### PR TITLE
Circuit breaker

### DIFF
--- a/app/services/circuit_breaker.rb
+++ b/app/services/circuit_breaker.rb
@@ -1,0 +1,75 @@
+class CircuitBreaker
+  attr_reader :failute_threshold, :recovery_timeout
+
+  def initialize(failute_threshold: 5, recovery_timeout: 60)
+    @failute_threshold = failure_threshold
+    @recovery_timeout = recovery_timeout
+    @state = :closed
+    failure_count = 0
+    @latest_failure_time = nil
+  end
+
+  def call 
+    return handle_open_circuit if open?
+
+    begin
+      result = yield
+      reset_failure_count if closed?
+      result
+    rescue StandardError => e
+      handle_failure(e)
+    end    
+  end
+
+  private
+
+  def handle_failure(error)
+    @failure_count += 1
+    @latest_failure_time = Time.now
+
+    if @failure_count >= failure_threshold
+      open_circuit
+      puts "Circuit is now open: #{error.message}"
+    else 
+      raise error
+    end
+  end
+
+  def handle_open_circuit
+    if Time.now - @latest_failure_time >= recovery_timeout
+      begin
+        result = yield
+        close_circuit 
+        puts "Circuit is now closed"
+        result
+      rescue StandardError => e
+        open_circuit
+        puts "Circuit remains open: #{e.message}"
+      end
+    else 
+      puts "Circuit is open; request not allowed"
+    end
+  end
+
+  def open?
+    @state == :open
+  end
+
+  def closed?
+    @state == :closed
+  end
+
+  def open_circuit
+    @state = :open
+  end
+
+  def close_circuit
+    @state = :closed
+    reset_failure_count
+  end
+
+  def reset_failure_count
+    @failure_count = 0 
+  end
+end
+  

--- a/app/services/circuit_breaker.rb
+++ b/app/services/circuit_breaker.rb
@@ -1,8 +1,8 @@
 class CircuitBreaker
-  attr_reader :failute_threshold, :recovery_timeout
+  attr_reader :failure_threshold, :recovery_timeout
 
-  def initialize(failute_threshold: 5, recovery_timeout: 60)
-    @failute_threshold = failure_threshold
+  def initialize(failure_threshold: 3, recovery_timeout: 30)
+    @failure_threshold = failure_threshold
     @recovery_timeout = recovery_timeout
     @state = :closed
     failure_count = 0

--- a/spec/services/circuit_breaker_spec.rb
+++ b/spec/services/circuit_breaker_spec.rb
@@ -1,12 +1,15 @@
 require 'rails_helper'
 
 describe CircuitBreaker do
-  subject(:circuit_breaker) { described_class.new(failure_threshold: 2, recovery_timeout: 1) }
-
   context 'when operation is successful' do
     it 'allows the operation to run and stays closed' do
-      expect { |b| circuit_breaker.call(&b) }.to yield_control
-      expect(circuit_breaker.closed?).to be true
+      circuit_breaker = CircuitBreaker.new(failure_threshold: 2, recovery_timeout: 1)
+      
+      expect {
+        circuit_breaker.call {puts "Operation successful"} 
+    }.to output("Operation successful\n").to_stdout
+      
+      expect(circuit_breaker.send(:closed?)).to be true
     end
   end
 

--- a/spec/services/circuit_breaker_spec.rb
+++ b/spec/services/circuit_breaker_spec.rb
@@ -1,0 +1,34 @@
+require 'rails_helper'
+
+describe CircuitBreaker do
+  subject(:circuit_breaker) { described_class.new(failure_threshold: 2, recovery_timeout: 1) }
+
+  context 'when operation is successful' do
+    it 'allows the operation to run and stays closed' do
+      expect { |b| circuit_breaker.call(&b) }.to yield_control
+      expect(circuit_breaker.closed?).to be true
+    end
+  end
+
+  context 'when operation fails' do
+    let(:failing_operation) { -> { raise StandardError, 'Operation failed' } }
+
+    it 'opens after specified number of failures' do
+      expect { 
+        2.times { circuit_breaker.call(&failing_operation) rescue StandardError }
+      }.to change { circuit_breaker.open? }.from(false).to(true)
+    end
+  end
+
+  context 'after the recovery timeout' do
+    let(:failing_operation) { -> { raise StandardError, 'Operation failed' } }
+
+    it 'attempts to reset the circuit' do
+      2.times { circuit_breaker.call(&failing_operation) rescue StandardError }
+      sleep 1.1 # wait for recovery timeout
+
+      expect { |b| circuit_breaker.call(&b) }.to yield_control
+      expect(circuit_breaker.closed?).to be true
+    end
+  end
+end

--- a/spec/services/circuit_breaker_spec.rb
+++ b/spec/services/circuit_breaker_spec.rb
@@ -1,4 +1,4 @@
-require 'rails_helper'
+require "rails_helper"
 
 describe CircuitBreaker do
   context 'when operation is successful' do
@@ -14,12 +14,13 @@ describe CircuitBreaker do
   end
 
   context 'when operation fails' do
+    circuit_breaker = CircuitBreaker.new(failure_threshold: 2, recovery_timeout: 1)
     let(:failing_operation) { -> { raise StandardError, 'Operation failed' } }
 
     it 'opens after specified number of failures' do
       expect { 
         2.times { circuit_breaker.call(&failing_operation) rescue StandardError }
-      }.to change { circuit_breaker.open? }.from(false).to(true)
+      }.to change { circuit_breaker.send(:open?)}.from(false).to(true)
     end
   end
 


### PR DESCRIPTION
Added the circuit breaker feature with 3 relevant tests:

-Closed circuit (works as intended)
-Opening the circuit (Too many failed requests)
-Closing the circuit (After a recovery timeout)

A little tricky to test without the primary AWS S3 account, so I'll check back with you in the morning about if it's working.  It shouldn't affect it, but if it does, we can kill this branch.